### PR TITLE
Staging

### DIFF
--- a/apps/web/src/components/editor/CodeEditor.tsx
+++ b/apps/web/src/components/editor/CodeEditor.tsx
@@ -503,7 +503,9 @@ export const CodeEditor = forwardRef<CodeEditorHandle, CodeEditorProps>(
                     seenLines.add(err.line);
                     const lineInfo = tr.state.doc.line(err.line);
                     const from = lineInfo.from;
-                    const to = Math.max(lineInfo.from, lineInfo.to);
+                    const to = lineInfo.to;
+                    // Skip empty lines — mark decorations cannot have zero-length ranges
+                    if (from >= to) continue;
                     decos.push(errorMarkDeco.range(from, to));
                   }
                 }

--- a/apps/web/src/components/editor/EditorLayout.tsx
+++ b/apps/web/src/components/editor/EditorLayout.tsx
@@ -1218,11 +1218,17 @@ export function EditorLayout({
         e.preventDefault();
         handleImmediateSave();
       }
+      if ((e.ctrlKey || e.metaKey) && e.key === "w") {
+        e.preventDefault();
+        if (activeFileId) {
+          handleCloseTab(activeFileId);
+        }
+      }
     }
 
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [handleCompile, handleImmediateSave]);
+  }, [handleCompile, handleImmediateSave, activeFileId, handleCloseTab]);
 
   // ─── Refresh files ────────────────────────────────
 

--- a/apps/web/src/components/editor/EditorLayout.tsx
+++ b/apps/web/src/components/editor/EditorLayout.tsx
@@ -1218,17 +1218,11 @@ export function EditorLayout({
         e.preventDefault();
         handleImmediateSave();
       }
-      if ((e.ctrlKey || e.metaKey) && e.key === "w") {
-        e.preventDefault();
-        if (activeFileId) {
-          handleCloseTab(activeFileId);
-        }
-      }
     }
 
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [handleCompile, handleImmediateSave, activeFileId, handleCloseTab]);
+  }, [handleCompile, handleImmediateSave]);
 
   // ─── Refresh files ────────────────────────────────
 

--- a/apps/web/src/components/editor/FileTree.tsx
+++ b/apps/web/src/components/editor/FileTree.tsx
@@ -14,6 +14,8 @@ import {
   ChevronRight,
   ChevronDown,
   Flag,
+  Copy,
+  ClipboardPaste,
 } from "lucide-react";
 import FileIcon from "./FileIcon";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
@@ -117,6 +119,24 @@ function flattenTree(nodes: TreeNode[]): string[] {
   return result;
 }
 
+/** Generate a "copy" path for a file, avoiding collisions with existing paths. */
+function getCopyPath(originalPath: string, existingPaths: Set<string>): string {
+  const lastSlash = originalPath.lastIndexOf("/");
+  const dir = lastSlash >= 0 ? originalPath.slice(0, lastSlash + 1) : "";
+  const filename = lastSlash >= 0 ? originalPath.slice(lastSlash + 1) : originalPath;
+  const dotIdx = filename.lastIndexOf(".");
+  const name = dotIdx > 0 ? filename.slice(0, dotIdx) : filename;
+  const ext = dotIdx > 0 ? filename.slice(dotIdx) : "";
+
+  let candidate = `${dir}${name} copy${ext}`;
+  let counter = 2;
+  while (existingPaths.has(candidate)) {
+    candidate = `${dir}${name} copy ${counter}${ext}`;
+    counter++;
+  }
+  return candidate;
+}
+
 // ─── Folder Drag-and-Drop from OS ───────────────────
 
 async function collectDroppedFiles(
@@ -191,25 +211,34 @@ async function collectDroppedFiles(
 interface ContextMenuProps {
   x: number;
   y: number;
+  selectedCount: number;
   canSetEntrypoint: boolean;
   isEntrypoint: boolean;
+  hasCopied: boolean;
   onSetEntrypoint: () => void;
   onDelete: () => void;
   onRename: () => void;
+  onCopy: () => void;
+  onPaste: () => void;
   onClose: () => void;
 }
 
 function ContextMenu({
   x,
   y,
+  selectedCount,
   canSetEntrypoint,
   isEntrypoint,
+  hasCopied,
   onSetEntrypoint,
   onDelete,
   onRename,
+  onCopy,
+  onPaste,
   onClose,
 }: ContextMenuProps) {
   const menuRef = useRef<HTMLDivElement>(null);
+  const isMulti = selectedCount > 1;
 
   useEffect(() => {
     function handleClickOutside(e: MouseEvent) {
@@ -227,7 +256,7 @@ function ContextMenu({
       className="fixed z-50 min-w-[140px] rounded-lg border border-border bg-bg-secondary py-1 shadow-lg"
       style={{ left: x, top: y }}
     >
-      {canSetEntrypoint && (
+      {!isMulti && canSetEntrypoint && (
         <button
           type="button"
           disabled={isEntrypoint}
@@ -243,21 +272,41 @@ function ContextMenu({
           {isEntrypoint ? "Current entrypoint" : "Set as entrypoint"}
         </button>
       )}
+      {!isMulti && (
+        <button
+          type="button"
+          onClick={onRename}
+          className="flex w-full items-center gap-2 px-3 py-2 text-sm text-text-secondary transition-colors hover:bg-bg-elevated hover:text-text-primary"
+        >
+          <Pencil className="h-4 w-4" />
+          Rename
+        </button>
+      )}
       <button
         type="button"
-        onClick={onRename}
+        onClick={onCopy}
         className="flex w-full items-center gap-2 px-3 py-2 text-sm text-text-secondary transition-colors hover:bg-bg-elevated hover:text-text-primary"
       >
-        <Pencil className="h-4 w-4" />
-        Rename
+        <Copy className="h-4 w-4" />
+        {isMulti ? `Copy ${selectedCount} files` : "Copy"}
       </button>
+      {hasCopied && (
+        <button
+          type="button"
+          onClick={onPaste}
+          className="flex w-full items-center gap-2 px-3 py-2 text-sm text-text-secondary transition-colors hover:bg-bg-elevated hover:text-text-primary"
+        >
+          <ClipboardPaste className="h-4 w-4" />
+          Paste
+        </button>
+      )}
       <button
         type="button"
         onClick={onDelete}
         className="flex w-full items-center gap-2 px-3 py-2 text-sm text-error transition-colors hover:bg-bg-elevated"
       >
         <Trash2 className="h-4 w-4" />
-        Delete
+        {isMulti ? `Delete ${selectedCount} files` : "Delete"}
       </button>
     </div>
   );
@@ -522,6 +571,7 @@ export function FileTree({
   const [selectedFileIds, setSelectedFileIds] = useState<Set<string>>(new Set());
   const [lastClickedFileId, setLastClickedFileId] = useState<string | null>(null);
   const [bulkDeleteConfirm, setBulkDeleteConfirm] = useState<Set<string> | null>(null);
+  const [copiedFileIds, setCopiedFileIds] = useState<string[]>([]);
   const dragCounter = useRef(0);
   const inputRef = useRef<HTMLInputElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -556,6 +606,7 @@ export function FileTree({
 
       if (e.shiftKey && lastClickedFileId) {
         // Range select
+        e.preventDefault();
         const anchorIdx = flatFileIds.indexOf(lastClickedFileId);
         const targetIdx = flatFileIds.indexOf(fileId);
         if (anchorIdx !== -1 && targetIdx !== -1) {
@@ -564,6 +615,7 @@ export function FileTree({
           const range = new Set(flatFileIds.slice(start, end + 1));
           setSelectedFileIds(range);
         }
+        treeContainerRef.current?.focus();
       } else if (e.ctrlKey || e.metaKey) {
         // Toggle select
         setSelectedFileIds((prev) => {
@@ -576,6 +628,7 @@ export function FileTree({
           return next;
         });
         setLastClickedFileId(fileId);
+        treeContainerRef.current?.focus();
       } else {
         // Plain click — clear selection, open file
         setSelectedFileIds(new Set());
@@ -603,12 +656,25 @@ export function FileTree({
       } else if ((e.ctrlKey || e.metaKey) && e.key === "a") {
         e.preventDefault();
         setSelectedFileIds(new Set(flatFileIds));
+      } else if ((e.ctrlKey || e.metaKey) && e.key === "c") {
+        const ids = selectedFileIds.size > 0
+          ? [...selectedFileIds]
+          : activeFileId ? [activeFileId] : [];
+        if (ids.length > 0) {
+          e.preventDefault();
+          setCopiedFileIds(ids);
+        }
+      } else if ((e.ctrlKey || e.metaKey) && e.key === "v") {
+        if (copiedFileIds.length > 0) {
+          e.preventDefault();
+          handlePasteFiles();
+        }
       }
     }
 
     container.addEventListener("keydown", handleKeyDown);
     return () => container.removeEventListener("keydown", handleKeyDown);
-  }, [readOnly, selectedFileIds, flatFileIds]);
+  }, [readOnly, selectedFileIds, flatFileIds, activeFileId, copiedFileIds, handlePasteFiles]);
 
   // ─── Prune stale selections when files change ──────
 
@@ -643,6 +709,46 @@ export function FileTree({
       }
     },
     [bulkDeleteConfirm, onFilesChanged, projectId, withShareToken]
+  );
+
+  // ─── Copy & Paste files ─────────────────────────────
+
+  const handlePasteFiles = useCallback(
+    async () => {
+      if (copiedFileIds.length === 0) return;
+      const existingPaths = new Set(files.map((f) => f.path));
+
+      try {
+        for (const fileId of copiedFileIds) {
+          const file = files.find((f) => f.id === fileId);
+          if (!file || file.isDirectory) continue;
+
+          // Fetch file content
+          const res = await fetch(
+            withShareToken(`/api/projects/${projectId}/files/${fileId}`)
+          );
+          if (!res.ok) continue;
+          const data = await res.json();
+
+          // Create copy with new name
+          const copyPath = getCopyPath(file.path, existingPaths);
+          existingPaths.add(copyPath);
+
+          await fetch(withShareToken(`/api/projects/${projectId}/files`), {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              path: copyPath,
+              content: data.content ?? "",
+            }),
+          });
+        }
+        onFilesChanged();
+      } catch {
+        // Silently fail
+      }
+    },
+    [copiedFileIds, files, onFilesChanged, projectId, withShareToken]
   );
 
   // ─── Rename API call ──────────────────────────────
@@ -915,9 +1021,13 @@ export function FileTree({
   const handleContextMenu = useCallback(
     (e: React.MouseEvent, file: ProjectFile) => {
       e.preventDefault();
+      // If right-clicking a file not in the selection, clear selection
+      if (!selectedFileIds.has(file.id)) {
+        setSelectedFileIds(new Set());
+      }
       setContextMenu({ x: e.clientX, y: e.clientY, file });
     },
-    []
+    [selectedFileIds]
   );
 
   const closeContextMenu = useCallback(() => {
@@ -1090,6 +1200,7 @@ export function FileTree({
         <ContextMenu
           x={contextMenu.x}
           y={contextMenu.y}
+          selectedCount={selectedFileIds.has(contextMenu.file.id) ? selectedFileIds.size : 1}
           canSetEntrypoint={
             !contextMenu.file.isDirectory &&
             contextMenu.file.path.toLowerCase().endsWith(".tex")
@@ -1100,13 +1211,29 @@ export function FileTree({
             closeContextMenu();
           }}
           onDelete={() => {
-            handleDeleteFile(contextMenu.file.id);
+            if (selectedFileIds.has(contextMenu.file.id) && selectedFileIds.size > 1) {
+              setBulkDeleteConfirm(new Set(selectedFileIds));
+            } else {
+              handleDeleteFile(contextMenu.file.id);
+            }
             closeContextMenu();
           }}
           onRename={() => {
             setRenamingFileId(contextMenu.file.id);
             closeContextMenu();
           }}
+          onCopy={() => {
+            const ids = selectedFileIds.has(contextMenu.file.id) && selectedFileIds.size > 1
+              ? [...selectedFileIds]
+              : [contextMenu.file.id];
+            setCopiedFileIds(ids);
+            closeContextMenu();
+          }}
+          onPaste={() => {
+            handlePasteFiles();
+            closeContextMenu();
+          }}
+          hasCopied={copiedFileIds.length > 0}
           onClose={closeContextMenu}
         />
       )}

--- a/apps/web/src/components/editor/FileTree.tsx
+++ b/apps/web/src/components/editor/FileTree.tsx
@@ -639,6 +639,46 @@ export function FileTree({
     [readOnly, lastClickedFileId, flatFileIds, onFileSelect]
   );
 
+  // ─── Copy & Paste files ─────────────────────────────
+
+  const handlePasteFiles = useCallback(
+    async () => {
+      if (copiedFileIds.length === 0) return;
+      const existingPaths = new Set(files.map((f) => f.path));
+
+      try {
+        for (const fileId of copiedFileIds) {
+          const file = files.find((f) => f.id === fileId);
+          if (!file || file.isDirectory) continue;
+
+          // Fetch file content
+          const res = await fetch(
+            withShareToken(`/api/projects/${projectId}/files/${fileId}`)
+          );
+          if (!res.ok) continue;
+          const data = await res.json();
+
+          // Create copy with new name
+          const copyPath = getCopyPath(file.path, existingPaths);
+          existingPaths.add(copyPath);
+
+          await fetch(withShareToken(`/api/projects/${projectId}/files`), {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              path: copyPath,
+              content: data.content ?? "",
+            }),
+          });
+        }
+        onFilesChanged();
+      } catch {
+        // Silently fail
+      }
+    },
+    [copiedFileIds, files, onFilesChanged, projectId, withShareToken]
+  );
+
   // ─── Keyboard shortcuts (scoped to tree container) ─
 
   useEffect(() => {
@@ -709,46 +749,6 @@ export function FileTree({
       }
     },
     [bulkDeleteConfirm, onFilesChanged, projectId, withShareToken]
-  );
-
-  // ─── Copy & Paste files ─────────────────────────────
-
-  const handlePasteFiles = useCallback(
-    async () => {
-      if (copiedFileIds.length === 0) return;
-      const existingPaths = new Set(files.map((f) => f.path));
-
-      try {
-        for (const fileId of copiedFileIds) {
-          const file = files.find((f) => f.id === fileId);
-          if (!file || file.isDirectory) continue;
-
-          // Fetch file content
-          const res = await fetch(
-            withShareToken(`/api/projects/${projectId}/files/${fileId}`)
-          );
-          if (!res.ok) continue;
-          const data = await res.json();
-
-          // Create copy with new name
-          const copyPath = getCopyPath(file.path, existingPaths);
-          existingPaths.add(copyPath);
-
-          await fetch(withShareToken(`/api/projects/${projectId}/files`), {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({
-              path: copyPath,
-              content: data.content ?? "",
-            }),
-          });
-        }
-        onFilesChanged();
-      } catch {
-        // Silently fail
-      }
-    },
-    [copiedFileIds, files, onFilesChanged, projectId, withShareToken]
   );
 
   // ─── Rename API call ──────────────────────────────

--- a/apps/web/src/components/editor/FileTree.tsx
+++ b/apps/web/src/components/editor/FileTree.tsx
@@ -617,9 +617,12 @@ export function FileTree({
         }
         treeContainerRef.current?.focus();
       } else if (e.ctrlKey || e.metaKey) {
-        // Toggle select
+        // Toggle select — include activeFileId if starting fresh
         setSelectedFileIds((prev) => {
           const next = new Set(prev);
+          if (next.size === 0 && activeFileId && activeFileId !== fileId) {
+            next.add(activeFileId);
+          }
           if (next.has(fileId)) {
             next.delete(fileId);
           } else {
@@ -651,25 +654,48 @@ export function FileTree({
           const file = files.find((f) => f.id === fileId);
           if (!file || file.isDirectory) continue;
 
-          // Fetch file content
-          const res = await fetch(
-            withShareToken(`/api/projects/${projectId}/files/${fileId}`)
-          );
-          if (!res.ok) continue;
-          const data = await res.json();
-
-          // Create copy with new name
           const copyPath = getCopyPath(file.path, existingPaths);
           existingPaths.add(copyPath);
 
-          await fetch(withShareToken(`/api/projects/${projectId}/files`), {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({
-              path: copyPath,
-              content: data.content ?? "",
-            }),
-          });
+          const isBinary = file.mimeType?.startsWith("image/") ||
+            file.mimeType === "application/pdf" ||
+            file.mimeType === "application/octet-stream";
+
+          if (isBinary) {
+            // Binary files: fetch raw bytes and upload via FormData
+            const res = await fetch(
+              withShareToken(`/api/projects/${projectId}/files/${fileId}?raw`)
+            );
+            if (!res.ok) continue;
+            const blob = await res.blob();
+            const NativeFile = globalThis.File;
+            const copyFile = new NativeFile([blob], copyPath.split("/").pop()!, { type: file.mimeType ?? undefined });
+
+            const formData = new FormData();
+            formData.append("files", copyFile);
+            formData.append("paths", copyPath);
+
+            await fetch(
+              withShareToken(`/api/projects/${projectId}/files/upload`),
+              { method: "POST", body: formData }
+            );
+          } else {
+            // Text files: fetch JSON content and create via POST
+            const res = await fetch(
+              withShareToken(`/api/projects/${projectId}/files/${fileId}`)
+            );
+            if (!res.ok) continue;
+            const data = await res.json();
+
+            await fetch(withShareToken(`/api/projects/${projectId}/files`), {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({
+                path: copyPath,
+                content: data.content ?? "",
+              }),
+            });
+          }
         }
         onFilesChanged();
       } catch {
@@ -690,6 +716,9 @@ export function FileTree({
         if (selectedFileIds.size > 0) {
           e.preventDefault();
           setBulkDeleteConfirm(new Set(selectedFileIds));
+        } else if (activeFileId) {
+          e.preventDefault();
+          setDeleteConfirm({ fileId: activeFileId });
         }
       } else if (e.key === "Escape") {
         setSelectedFileIds(new Set());

--- a/apps/web/src/components/editor/FileTree.tsx
+++ b/apps/web/src/components/editor/FileTree.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback, useRef, useEffect } from "react";
+import { useState, useCallback, useRef, useEffect, useMemo } from "react";
 import { cn } from "@/lib/utils/cn";
 import {
   File,
@@ -98,6 +98,23 @@ function buildTree(files: ProjectFile[]): TreeNode[] {
 function getParentPath(filePath: string): string {
   const idx = filePath.lastIndexOf("/");
   return idx === -1 ? "" : filePath.slice(0, idx);
+}
+
+/** DFS traversal returning file IDs in visual order (skips directories). */
+function flattenTree(nodes: TreeNode[]): string[] {
+  const result: string[] = [];
+  function walk(list: TreeNode[]) {
+    for (const node of list) {
+      if (!node.isDirectory && node.file) {
+        result.push(node.file.id);
+      }
+      if (node.children.length > 0) {
+        walk(node.children);
+      }
+    }
+  }
+  walk(nodes);
+  return result;
 }
 
 // ─── Folder Drag-and-Drop from OS ───────────────────
@@ -255,7 +272,9 @@ interface TreeNodeItemProps {
   mainFilePath: string;
   renamingFileId: string | null;
   dropTargetPath: string | null;
+  selectedFileIds: Set<string>;
   onFileSelect: (fileId: string, filePath: string) => void;
+  onFileClick: (fileId: string, filePath: string, e: React.MouseEvent) => void;
   onDeleteFile: (fileId: string) => void;
   onContextMenu: (e: React.MouseEvent, file: ProjectFile) => void;
   onRenameSubmit: (fileId: string, oldPath: string, newName: string) => void;
@@ -273,7 +292,9 @@ function TreeNodeItem({
   mainFilePath,
   renamingFileId,
   dropTargetPath,
+  selectedFileIds,
   onFileSelect,
+  onFileClick,
   onDeleteFile,
   onContextMenu,
   onRenameSubmit,
@@ -287,6 +308,7 @@ function TreeNodeItem({
   const [renameValue, setRenameValue] = useState("");
   const renameInputRef = useRef<HTMLInputElement>(null);
   const isActive = node.file?.id === activeFileId;
+  const isSelected = node.file ? selectedFileIds.has(node.file.id) : false;
   const isRenaming = node.file?.id === renamingFileId;
   const isEntrypoint = !!node.file && !node.isDirectory && node.file.path === mainFilePath;
 
@@ -312,12 +334,12 @@ function TreeNodeItem({
     }
   }, [isRenaming, node.name, node.isDirectory]);
 
-  function handleClick() {
+  function handleClick(e: React.MouseEvent) {
     if (isRenaming) return;
     if (node.isDirectory) {
       setExpanded(!expanded);
     } else if (node.file) {
-      onFileSelect(node.file.id, node.file.path);
+      onFileClick(node.file.id, node.file.path, e);
     }
   }
 
@@ -376,7 +398,9 @@ function TreeNodeItem({
           "flex w-full items-center gap-1.5 rounded-md px-2 py-1 text-left text-sm transition-colors",
           isActive
             ? "bg-accent/15 text-accent"
-            : "text-text-secondary hover:bg-bg-elevated hover:text-text-primary",
+            : isSelected
+              ? "bg-accent/10 text-accent/80"
+              : "text-text-secondary hover:bg-bg-elevated hover:text-text-primary",
           dropTargetPath === node.path && node.isDirectory && "ring-2 ring-accent/50 bg-accent/10"
         )}
         style={{ paddingLeft: `${depth * 12 + 8}px` }}
@@ -442,7 +466,9 @@ function TreeNodeItem({
               mainFilePath={mainFilePath}
               renamingFileId={renamingFileId}
               dropTargetPath={dropTargetPath}
+              selectedFileIds={selectedFileIds}
               onFileSelect={onFileSelect}
+              onFileClick={onFileClick}
               onDeleteFile={onDeleteFile}
               onContextMenu={onContextMenu}
               onRenameSubmit={onRenameSubmit}
@@ -493,9 +519,13 @@ export function FileTree({
   const [dropTargetPath, setDropTargetPath] = useState<string | null>(null);
   const [deleteConfirm, setDeleteConfirm] = useState<{ fileId: string } | null>(null);
   const [alertMessage, setAlertMessage] = useState<string | null>(null);
+  const [selectedFileIds, setSelectedFileIds] = useState<Set<string>>(new Set());
+  const [lastClickedFileId, setLastClickedFileId] = useState<string | null>(null);
+  const [bulkDeleteConfirm, setBulkDeleteConfirm] = useState<Set<string> | null>(null);
   const dragCounter = useRef(0);
   const inputRef = useRef<HTMLInputElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const treeContainerRef = useRef<HTMLDivElement>(null);
 
   const withShareToken = useCallback(
     (url: string) => {
@@ -513,6 +543,107 @@ export function FileTree({
   }, [creating]);
 
   const tree = buildTree(files);
+  const flatFileIds = useMemo(() => flattenTree(tree), [tree]);
+
+  // ─── Multi-select click handler ────────────────────
+
+  const handleFileClick = useCallback(
+    (fileId: string, filePath: string, e: React.MouseEvent) => {
+      if (readOnly) {
+        onFileSelect(fileId, filePath);
+        return;
+      }
+
+      if (e.shiftKey && lastClickedFileId) {
+        // Range select
+        const anchorIdx = flatFileIds.indexOf(lastClickedFileId);
+        const targetIdx = flatFileIds.indexOf(fileId);
+        if (anchorIdx !== -1 && targetIdx !== -1) {
+          const start = Math.min(anchorIdx, targetIdx);
+          const end = Math.max(anchorIdx, targetIdx);
+          const range = new Set(flatFileIds.slice(start, end + 1));
+          setSelectedFileIds(range);
+        }
+      } else if (e.ctrlKey || e.metaKey) {
+        // Toggle select
+        setSelectedFileIds((prev) => {
+          const next = new Set(prev);
+          if (next.has(fileId)) {
+            next.delete(fileId);
+          } else {
+            next.add(fileId);
+          }
+          return next;
+        });
+        setLastClickedFileId(fileId);
+      } else {
+        // Plain click — clear selection, open file
+        setSelectedFileIds(new Set());
+        setLastClickedFileId(fileId);
+        onFileSelect(fileId, filePath);
+      }
+    },
+    [readOnly, lastClickedFileId, flatFileIds, onFileSelect]
+  );
+
+  // ─── Keyboard shortcuts (scoped to tree container) ─
+
+  useEffect(() => {
+    const container = treeContainerRef.current;
+    if (!container || readOnly) return;
+
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === "Delete" || e.key === "Backspace") {
+        if (selectedFileIds.size > 0) {
+          e.preventDefault();
+          setBulkDeleteConfirm(new Set(selectedFileIds));
+        }
+      } else if (e.key === "Escape") {
+        setSelectedFileIds(new Set());
+      } else if ((e.ctrlKey || e.metaKey) && e.key === "a") {
+        e.preventDefault();
+        setSelectedFileIds(new Set(flatFileIds));
+      }
+    }
+
+    container.addEventListener("keydown", handleKeyDown);
+    return () => container.removeEventListener("keydown", handleKeyDown);
+  }, [readOnly, selectedFileIds, flatFileIds]);
+
+  // ─── Prune stale selections when files change ──────
+
+  useEffect(() => {
+    const validIds = new Set(files.filter((f) => !f.isDirectory).map((f) => f.id));
+    setSelectedFileIds((prev) => {
+      const pruned = new Set([...prev].filter((id) => validIds.has(id)));
+      if (pruned.size !== prev.size) return pruned;
+      return prev;
+    });
+  }, [files]);
+
+  // ─── Bulk delete ───────────────────────────────────
+
+  const confirmBulkDelete = useCallback(
+    async () => {
+      if (!bulkDeleteConfirm) return;
+      const idsToDelete = [...bulkDeleteConfirm];
+      setBulkDeleteConfirm(null);
+      setSelectedFileIds(new Set());
+
+      try {
+        for (const fileId of idsToDelete) {
+          await fetch(
+            withShareToken(`/api/projects/${projectId}/files/${fileId}`),
+            { method: "DELETE" }
+          );
+        }
+        onFilesChanged();
+      } catch {
+        // Silently fail
+      }
+    },
+    [bulkDeleteConfirm, onFilesChanged, projectId, withShareToken]
+  );
 
   // ─── Rename API call ──────────────────────────────
 
@@ -905,7 +1036,11 @@ export function FileTree({
       )}
 
       {/* Tree content */}
-      <div className="flex-1 overflow-y-auto px-1 py-1">
+      <div
+        ref={treeContainerRef}
+        tabIndex={0}
+        className="flex-1 overflow-y-auto px-1 py-1 outline-none"
+      >
         {/* Drop overlay */}
         {isDraggingOver && (
           <div className="flex flex-col items-center justify-center rounded-lg border-2 border-dashed border-accent/40 px-4 py-6 text-center mb-1">
@@ -935,7 +1070,9 @@ export function FileTree({
             mainFilePath={mainFilePath}
             renamingFileId={renamingFileId}
             dropTargetPath={dropTargetPath}
+            selectedFileIds={selectedFileIds}
             onFileSelect={onFileSelect}
+            onFileClick={handleFileClick}
             onDeleteFile={handleDeleteFile}
             onContextMenu={handleContextMenu}
             onRenameSubmit={handleRenameSubmit}
@@ -983,6 +1120,17 @@ export function FileTree({
         variant="danger"
         onConfirm={confirmDelete}
         onCancel={() => setDeleteConfirm(null)}
+      />
+
+      {/* Bulk delete confirmation dialog */}
+      <ConfirmDialog
+        open={bulkDeleteConfirm !== null}
+        title="Delete files"
+        message={`Are you sure you want to delete ${bulkDeleteConfirm?.size ?? 0} file(s)? This action cannot be undone.`}
+        confirmLabel="Delete All"
+        variant="danger"
+        onConfirm={confirmBulkDelete}
+        onCancel={() => setBulkDeleteConfirm(null)}
       />
 
       {/* Alert dialog */}

--- a/apps/web/src/components/editor/FileTree.tsx
+++ b/apps/web/src/components/editor/FileTree.tsx
@@ -16,6 +16,7 @@ import {
   Flag,
 } from "lucide-react";
 import FileIcon from "./FileIcon";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 
 // ─── Types ──────────────────────────────────────────
 
@@ -490,8 +491,11 @@ export function FileTree({
   const [isDraggingOver, setIsDraggingOver] = useState(false);
   const [uploading, setUploading] = useState(false);
   const [dropTargetPath, setDropTargetPath] = useState<string | null>(null);
+  const [deleteConfirm, setDeleteConfirm] = useState<{ fileId: string } | null>(null);
+  const [alertMessage, setAlertMessage] = useState<string | null>(null);
   const dragCounter = useRef(0);
   const inputRef = useRef<HTMLInputElement>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
   const withShareToken = useCallback(
     (url: string) => {
@@ -714,11 +718,17 @@ export function FileTree({
   // ─── Delete file ─────────────────────────────────
 
   const handleDeleteFile = useCallback(
-    async (fileId: string) => {
-      const confirmed = window.confirm(
-        "Are you sure you want to delete this file?"
-      );
-      if (!confirmed) return;
+    (fileId: string) => {
+      setDeleteConfirm({ fileId });
+    },
+    []
+  );
+
+  const confirmDelete = useCallback(
+    async () => {
+      if (!deleteConfirm) return;
+      const { fileId } = deleteConfirm;
+      setDeleteConfirm(null);
 
       try {
         const res = await fetch(
@@ -737,7 +747,7 @@ export function FileTree({
         // Silently fail
       }
     },
-    [onFilesChanged, onMainFileChange, projectId, withShareToken]
+    [deleteConfirm, onFilesChanged, onMainFileChange, projectId, withShareToken]
   );
 
   const handleSetEntrypoint = useCallback(
@@ -754,7 +764,7 @@ export function FileTree({
 
         if (!res.ok) {
           const data = await res.json().catch(() => ({}));
-          window.alert(data.error || "Failed to set entrypoint");
+          setAlertMessage(data.error || "Failed to set entrypoint");
           return;
         }
 
@@ -763,7 +773,7 @@ export function FileTree({
           typeof data.mainFile === "string" ? data.mainFile : filePath
         );
       } catch {
-        window.alert("Failed to set entrypoint");
+        setAlertMessage("Failed to set entrypoint");
       }
     },
     [onMainFileChange, projectId, withShareToken]
@@ -794,6 +804,25 @@ export function FileTree({
       onDragOver={handleDragOver}
       onDrop={handleDrop}
     >
+      {/* Hidden file picker input */}
+      <input
+        ref={fileInputRef}
+        type="file"
+        multiple
+        accept=".tex,.bib,.cls,.sty,.bst,.png,.jpg,.jpeg,.gif,.svg,.pdf,.eps,.ps,.txt,.md,.csv,.dat,.tikz,.pgf"
+        className="hidden"
+        onChange={(e) => {
+          const fileList = e.target.files;
+          if (!fileList || fileList.length === 0) return;
+          const entries: { file: File; path: string }[] = [];
+          for (let i = 0; i < fileList.length; i++) {
+            entries.push({ file: fileList[i], path: fileList[i].name });
+          }
+          uploadFiles(entries);
+          e.target.value = "";
+        }}
+      />
+
       {/* Header */}
       <div className="flex items-center justify-between border-b border-border px-3 py-2">
         <span className="text-xs font-semibold uppercase tracking-wider text-text-muted">
@@ -822,6 +851,14 @@ export function FileTree({
               className="rounded p-1 text-text-muted transition-colors hover:text-text-primary hover:bg-bg-elevated"
             >
               <FolderPlus className="h-4 w-4" />
+            </button>
+            <button
+              type="button"
+              onClick={() => fileInputRef.current?.click()}
+              title="Upload Files"
+              className="rounded p-1 text-text-muted transition-colors hover:text-text-primary hover:bg-bg-elevated"
+            >
+              <Upload className="h-4 w-4" />
             </button>
           </div>
         )}
@@ -936,6 +973,27 @@ export function FileTree({
           onClose={closeContextMenu}
         />
       )}
+
+      {/* Delete confirmation dialog */}
+      <ConfirmDialog
+        open={deleteConfirm !== null}
+        title="Delete file"
+        message="Are you sure you want to delete this file? This action cannot be undone."
+        confirmLabel="Delete"
+        variant="danger"
+        onConfirm={confirmDelete}
+        onCancel={() => setDeleteConfirm(null)}
+      />
+
+      {/* Alert dialog */}
+      <ConfirmDialog
+        open={alertMessage !== null}
+        title="Error"
+        message={alertMessage ?? ""}
+        alert
+        onConfirm={() => setAlertMessage(null)}
+        onCancel={() => setAlertMessage(null)}
+      />
     </div>
   );
 }

--- a/apps/web/src/components/ui/confirm-dialog.tsx
+++ b/apps/web/src/components/ui/confirm-dialog.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { X } from "lucide-react";
+import { cn } from "@/lib/utils/cn";
+
+interface ConfirmDialogProps {
+  open: boolean;
+  title: string;
+  message: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  variant?: "danger" | "default";
+  /** When true, only shows a single dismiss button (alert mode). */
+  alert?: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export function ConfirmDialog({
+  open,
+  title,
+  message,
+  confirmLabel = "Confirm",
+  cancelLabel = "Cancel",
+  variant = "default",
+  alert = false,
+  onConfirm,
+  onCancel,
+}: ConfirmDialogProps) {
+  const confirmRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if (open) {
+      confirmRef.current?.focus();
+    }
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        onCancel();
+      }
+    }
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [open, onCancel]);
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      <div
+        className="absolute inset-0 bg-black/60 backdrop-blur-sm"
+        onClick={onCancel}
+      />
+
+      <div className="relative z-10 w-full max-w-sm rounded-lg border border-border bg-bg-primary p-5 shadow-xl">
+        <div className="mb-3 flex items-center justify-between">
+          <h3 className="text-sm font-semibold text-text-primary">{title}</h3>
+          <button
+            type="button"
+            onClick={onCancel}
+            className="rounded-md p-1 text-text-muted transition-colors hover:text-text-primary hover:bg-bg-elevated"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        <p className="mb-5 text-sm text-text-secondary">{message}</p>
+
+        <div className="flex items-center justify-end gap-2">
+          {!alert && (
+            <button
+              type="button"
+              onClick={onCancel}
+              className="rounded-lg border border-border bg-bg-secondary px-3 py-1.5 text-sm text-text-primary transition-colors hover:bg-bg-elevated"
+            >
+              {cancelLabel}
+            </button>
+          )}
+          <button
+            ref={confirmRef}
+            type="button"
+            onClick={onConfirm}
+            className={cn(
+              "rounded-lg px-3 py-1.5 text-sm font-medium transition-colors",
+              variant === "danger"
+                ? "bg-error text-white hover:bg-error/90"
+                : "bg-accent text-bg-primary hover:bg-accent-hover"
+            )}
+          >
+            {alert ? "OK" : confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/lib/compiler/preamble.ts
+++ b/apps/web/src/lib/compiler/preamble.ts
@@ -1,0 +1,149 @@
+import fs from "fs/promises";
+import path from "path";
+
+/**
+ * Map of LaTeX command/environment patterns to required packages.
+ * Each entry is [regex, packageName].
+ */
+const PACKAGE_RULES: [RegExp, string][] = [
+  // amsmath
+  [/\\binom\b/, "amsmath"],
+  [/\\tfrac\b/, "amsmath"],
+  [/\\dfrac\b/, "amsmath"],
+  [/\\operatorname\b/, "amsmath"],
+  [/\\DeclareMathOperator\b/, "amsmath"],
+  [/\\intertext\b/, "amsmath"],
+  [/\\text\s*\{/, "amsmath"],
+  [/\\begin\s*\{align\*?\}/, "amsmath"],
+  [/\\begin\s*\{gather\*?\}/, "amsmath"],
+  [/\\begin\s*\{multline\*?\}/, "amsmath"],
+  [/\\begin\s*\{equation\*\}/, "amsmath"],
+  [/\\begin\s*\{split\}/, "amsmath"],
+  [/\\begin\s*\{aligned\}/, "amsmath"],
+  [/\\begin\s*\{gathered\}/, "amsmath"],
+
+  // amssymb
+  [/\\mathbb\b/, "amssymb"],
+  [/\\mathfrak\b/, "amssymb"],
+
+  // amsthm
+  [/\\begin\s*\{theorem\}/, "amsthm"],
+  [/\\begin\s*\{lemma\}/, "amsthm"],
+  [/\\begin\s*\{proof\}/, "amsthm"],
+  [/\\theoremstyle\b/, "amsthm"],
+
+  // hyperref
+  [/\\url\s*\{/, "hyperref"],
+  [/\\href\s*\{/, "hyperref"],
+];
+
+/**
+ * Strip %-comments from a line (respecting escaped \%).
+ */
+function stripComment(line: string): string {
+  let i = 0;
+  while (i < line.length) {
+    if (line[i] === "%" && (i === 0 || line[i - 1] !== "\\")) {
+      return line.slice(0, i);
+    }
+    i++;
+  }
+  return line;
+}
+
+/**
+ * Extract the set of packages already loaded via \usepackage in the preamble.
+ */
+function findLoadedPackages(preamble: string): Set<string> {
+  const loaded = new Set<string>();
+  // Match \usepackage[...]{pkg1,pkg2,...} or \usepackage{pkg1,pkg2,...}
+  const re = /\\usepackage\s*(?:\[[^\]]*\])?\s*\{([^}]+)\}/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(preamble)) !== null) {
+    for (const pkg of m[1].split(",")) {
+      loaded.add(pkg.trim());
+    }
+  }
+  return loaded;
+}
+
+/**
+ * Scan a .tex source and inject missing \usepackage declarations into the
+ * preamble of the build copy. Returns the (possibly modified) source.
+ */
+export function injectMissingPackagesInSource(source: string): string {
+  const docClassMatch = source.match(/\\documentclass\b/);
+  const beginDocMatch = source.match(/\\begin\s*\{document\}/);
+  if (!docClassMatch || !beginDocMatch) {
+    // Not a standard LaTeX document — skip
+    return source;
+  }
+
+  const beginDocIndex = source.indexOf(beginDocMatch[0]);
+
+  // Extract preamble (between \documentclass and \begin{document}), stripping comments
+  const preambleRaw = source.slice(docClassMatch.index!, beginDocIndex);
+  const preambleStripped = preambleRaw
+    .split("\n")
+    .map(stripComment)
+    .join("\n");
+
+  const loadedPackages = findLoadedPackages(preambleStripped);
+
+  // Scan the full file (with comments stripped) for command usage
+  const fullStripped = source
+    .split("\n")
+    .map(stripComment)
+    .join("\n");
+
+  const needed = new Set<string>();
+  for (const [pattern, pkg] of PACKAGE_RULES) {
+    if (loadedPackages.has(pkg)) continue;
+    if (pattern.test(fullStripped)) {
+      needed.add(pkg);
+    }
+  }
+
+  if (needed.size === 0) {
+    return source;
+  }
+
+  // amssymb loads amsmath implicitly, so if both are needed only inject amssymb
+  // (amsmath is a dependency of amssymb in TeX Live)
+  // Actually amssymb does NOT load amsmath — they are independent. Keep both.
+
+  const injections = Array.from(needed)
+    .sort()
+    .map((pkg) => `\\usepackage{${pkg}}`)
+    .join("\n");
+
+  // Insert just before \begin{document}
+  const before = source.slice(0, beginDocIndex);
+  const after = source.slice(beginDocIndex);
+
+  return `${before}${injections}\n${after}`;
+}
+
+/**
+ * Scan the main .tex file in the build directory and inject missing packages
+ * into the build copy. The original project files are never touched.
+ */
+export async function injectMissingPackages(
+  buildDir: string,
+  mainFile: string
+): Promise<void> {
+  const filePath = path.join(buildDir, mainFile);
+
+  let source: string;
+  try {
+    source = await fs.readFile(filePath, "utf-8");
+  } catch {
+    // File doesn't exist or can't be read — nothing to do
+    return;
+  }
+
+  const patched = injectMissingPackagesInSource(source);
+  if (patched !== source) {
+    await fs.writeFile(filePath, patched, "utf-8");
+  }
+}

--- a/apps/web/src/lib/compiler/runner.ts
+++ b/apps/web/src/lib/compiler/runner.ts
@@ -15,6 +15,7 @@ import {
 import { getProjectDir, getPdfPath, fileExists } from "@/lib/storage";
 import { runCompileContainer } from "./docker";
 import { parseLatexLog } from "./logParser";
+import { injectMissingPackages } from "./preamble";
 import { broadcastBuildUpdate } from "@/lib/websocket/server";
 import {
   COMPILE_CANCEL_KEY_PREFIX,
@@ -222,6 +223,9 @@ class CompileRunner {
       const projectDir = getProjectDir(storageUserId, projectId);
       await copyDir(projectDir, buildDir);
       console.log(`[Runner] Copied project files to build dir: ${buildDir}`);
+
+      // Step 2.5: Auto-inject missing LaTeX packages into the build copy
+      await injectMissingPackages(buildDir, mainFile);
 
       // Step 3: Run the Docker container against the isolated build dir
       const containerResult = await runCompileContainer({


### PR DESCRIPTION

  ## Summary
  - **Multi-select in FileTree**: Ctrl+Click toggles individual files, Shift+Click range-selects, with proper visual highlighting
  - **Bulk operations**: Context menu adapts to multi-select — hides Rename/Set Entrypoint, shows "Delete N files", deletes all selected
  - **Ctrl+C / Ctrl+V file duplication**: Copy selected files and paste as duplicates (e.g., `main.tex` → `main copy.tex`), works for both text files and binary files (images, PDFs)
  - **Ctrl+A**: Select all files in the tree when focused
  - **Delete / Backspace key**: Deletes selected files (multi or single active file) with confirmation dialog
  - **Escape**: Clears file selection
  - **Copy/Paste in context menu**: Right-click access to Copy and Paste actions with clipboard state awareness
  - **Focus management**: Tree container properly retains focus after multi-select so keyboard shortcuts work immediately

And:- Fixes #22