### PR TITLE
fix(editor): stop auto-compile from re-enabling on every successful build

### DIFF
--- a/apps/web/src/components/editor/EditorLayout.tsx
+++ b/apps/web/src/components/editor/EditorLayout.tsx
@@ -512,7 +512,6 @@ export function EditorLayout({
           if (build.status === "success") {
             setPdfUrl(withShareToken(`/api/projects/${project.id}/pdf?t=${Date.now()}`));
             restoreViewPositionsAfterBuild();
-            setAutoCompileEnabled(true);
 
             // If file was changed during build, recompile
             if (pendingRecompileRef.current) {
@@ -674,7 +673,6 @@ export function EditorLayout({
       if (data.status === "success") {
         setPdfUrl(withShareToken(`/api/projects/${project.id}/pdf?t=${Date.now()}`));
         restoreViewPositionsAfterBuild();
-        setAutoCompileEnabled(true);
 
         // If file was changed during build, recompile with latest content
         if (pendingRecompileRef.current) {


### PR DESCRIPTION
## Summary
- Removes the two `setAutoCompileEnabled(true)` calls that fired on every successful build (one in the WebSocket `onBuildComplete` path, one in the polling fallback).
- Auto-compile now stays in whatever state the user set it to. The error/timeout disable behavior is unchanged (still flips off as a safety).

## Why
After a manual compile with auto-compile turned off, the toggle silently flipped back on, forcing users to re-disable it before every compile.

## Test plan
- [x] Toggle auto-compile **off**, manually compile a project to success, confirm the toggle stays **off**.
- [x] With auto-compile **on**, edit a file and confirm auto-compile still runs on idle.
- [x] Trigger an error build with auto-compile on, confirm the toggle still flips off automatically (existing safety behavior).

Closes #32