### PR TITLE
fix(editor): stop cursor from jumping back after auto-compile

### DIFF
--- a/apps/web/src/components/editor/EditorLayout.tsx
+++ b/apps/web/src/components/editor/EditorLayout.tsx
@@ -237,10 +237,6 @@ export function EditorLayout({
   const codeEditorRef = useRef<CodeEditorHandle>(null);
   const pdfViewerRef = useRef<PdfViewerHandle>(null);
   const buildLogsPanelRef = useRef<ImperativePanelHandle>(null);
-  const editorScrollRef = useRef<number | null>(null);
-  const editorSelectionRef = useRef<{ anchor: number; head: number } | null>(
-    null
-  );
   const savedContentRef = useRef<Map<string, string>>(new Map());
   const fileContentsRef = useRef<Map<string, string>>(new Map());
   const pollIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
@@ -263,21 +259,12 @@ export function EditorLayout({
 
   const saveViewPositionsBeforeBuild = useCallback(() => {
     pdfViewerRef.current?.saveScrollPosition();
-    editorScrollRef.current = codeEditorRef.current?.getScrollPosition() ?? null;
-    editorSelectionRef.current = codeEditorRef.current?.getSelection() ?? null;
   }, []);
 
   const restoreViewPositionsAfterBuild = useCallback(() => {
-    requestAnimationFrame(() => {
-      if (editorScrollRef.current !== null) {
-        codeEditorRef.current?.setScrollPosition(editorScrollRef.current);
-      }
-      if (editorSelectionRef.current) {
-        codeEditorRef.current?.setSelection(editorSelectionRef.current);
-      }
-      editorScrollRef.current = null;
-      editorSelectionRef.current = null;
-    });
+    // PDF viewer handles its own restore on reload; the editor must NOT be
+    // touched here because the user keeps typing during auto-compile and
+    // forcing the cursor back to its pre-build position causes #31.
   }, []);
 
   const formatExpiry = useCallback((expiresAt: string | null | undefined) => {


### PR DESCRIPTION
## Summary
- Drops the editor selection/scroll-position snapshot taken at the start of every build, and the matching restore that ran on completion.
- PDF viewer still saves/restores its own scroll position — that part was correct and unaffected.

## Why
With auto-compile on, the user keeps typing during the 1–5s build window. Restoring the cursor to its pre-build position once the build finished snapped the caret backward by exactly the characters typed during the build, which is the "cursor shifts back by a few characters" behavior reported in #31.

The editor document is not modified by a build, so the snapshot/restore had no legitimate purpose for the editor.

## Test plan
- [x] With auto-compile on, type continuously through a 2s save+compile cycle; verify the caret stays where you're typing and does not jump.
- [x] After a successful build, verify the PDF preserves its scroll position (PDF restore should be unchanged).
- [x] Manual compile (Ctrl/Cmd+Enter): cursor remains in place across the build.

Closes #31