### PR TITLE
fix(editor): stop Ctrl+Z from overwriting a file with another file's contents

### DIFF
--- a/apps/web/src/components/editor/CodeEditor.tsx
+++ b/apps/web/src/components/editor/CodeEditor.tsx
@@ -299,6 +299,11 @@ export const CodeEditor = forwardRef<CodeEditorHandle, CodeEditorProps>(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const editorViewClassRef = useRef<any>(null);
 
+    // Store Transaction class so external dispatches can opt out of undo
+    // history (prevents Ctrl+Z from reverting to another file's contents).
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const transactionClassRef = useRef<any>(null);
+
     // ─── Remote cursor state & effects (CodeMirror StateField + StateEffect) ───
 
     // Store CodeMirror StateEffect/StateField refs for remote cursors
@@ -321,7 +326,8 @@ export const CodeEditor = forwardRef<CodeEditorHandle, CodeEditorProps>(
       let detachPointerDown: (() => void) | null = null;
 
       async function initEditor() {
-        const { EditorState, StateEffect, StateField } = await import("@codemirror/state");
+        const { EditorState, StateEffect, StateField, Transaction } = await import("@codemirror/state");
+        transactionClassRef.current = Transaction;
         const {
           EditorView,
           lineNumbers,
@@ -731,6 +737,7 @@ export const CodeEditor = forwardRef<CodeEditorHandle, CodeEditorProps>(
               anchor: Math.min(prevSel.anchor, nextMax),
               head: Math.min(prevSel.head, nextMax),
             },
+            annotations: [Transaction.addToHistory.of(false)],
           });
           requestAnimationFrame(() => {
             if (view) {
@@ -777,6 +784,7 @@ export const CodeEditor = forwardRef<CodeEditorHandle, CodeEditorProps>(
         const prevSel = view.state.selection.main;
         const prevScrollTop = view.scrollDOM.scrollTop;
         const nextMax = content.length;
+        const T = transactionClassRef.current;
         view.dispatch({
           changes: {
             from: 0,
@@ -787,6 +795,10 @@ export const CodeEditor = forwardRef<CodeEditorHandle, CodeEditorProps>(
             anchor: Math.min(prevSel.anchor, nextMax),
             head: Math.min(prevSel.head, nextMax),
           },
+          // Keep file-switch content swaps out of the undo history; otherwise
+          // Ctrl+Z on a freshly-opened file reverts to the previous file's
+          // contents and the resulting onChange auto-saves the corruption.
+          ...(T ? { annotations: [T.addToHistory.of(false)] } : {}),
         });
         requestAnimationFrame(() => {
           view.scrollDOM.scrollTop = prevScrollTop;
@@ -805,12 +817,15 @@ export const CodeEditor = forwardRef<CodeEditorHandle, CodeEditorProps>(
 
       isExternalUpdate.current = true;
       try {
+        const T = transactionClassRef.current;
         view.dispatch({
           changes: changes.map((c) => ({
             from: Math.min(c.from, view.state.doc.length),
             to: Math.min(c.to, view.state.doc.length),
             insert: c.insert,
           })),
+          // Remote edits shouldn't show up in this user's local undo stack.
+          ...(T ? { annotations: [T.addToHistory.of(false)] } : {}),
         });
       } catch {
         // If granular apply fails, we'll rely on the full content sync


### PR DESCRIPTION
## Summary
- Tags the three external CodeMirror dispatches in `CodeEditor.tsx` (file-switch content sync, late async-init sync, incoming remote collab edits) with `Transaction.addToHistory.of(false)`.
- The user's own edits remain in the undo stack — only the swaps performed by React effects are excluded.

## Why
Opening a non-main file dispatched the new content as a regular transaction, so CodeMirror's history recorded it. Pressing Ctrl+Z before making any edits replayed the inverse (restoring the previously displayed buffer — usually `main.tex`), and the resulting `onChange` then auto-saved that wrong content to disk. Result: the file on the server got irreversibly overwritten with `main.tex`.

## Test plan
- [x] Open `main.tex`, then switch to a different `.tex` file. Press Ctrl+Z immediately. The file's contents must not change.
- [x] Reload, confirm the file on disk is intact.
- [x] Make a real edit, press Ctrl+Z. Verify the edit is undone (user history still works).
- [x] In a collab session, have another user edit the same file. Press Ctrl+Z on your side and confirm you only undo your own edits, not theirs.

Closes #30